### PR TITLE
Making CC length an equality check

### DIFF
--- a/src/credit-card.validator.ts
+++ b/src/credit-card.validator.ts
@@ -26,7 +26,7 @@ export class CreditCardValidator {
     }
 
     for (let i = 0; i < card.length.length; i++) {
-      if (card.length[i] >= num.length && (card.luhn === false || this.creditCard.luhnCheck(num))) {
+      if (card.length[i] === num.length && (card.luhn === false || this.creditCard.luhnCheck(num))) {
         return null;
       }
     }    


### PR DESCRIPTION
I assume this is intended to verify the length of the card entered is appropriate.

As it was the validation will check e.g. expected card length is 13, entered is 2, 13 >= 2 so it will pass for any number that passes the luhn check (until the entered length is greater than the expected length, which seems like a less likely use case).

Since each valid length is included in the CC field, it seems more appropriate to validate only when the length matches one of the accepted lengths of that card type.